### PR TITLE
Add config for disable validation in specific presenters

### DIFF
--- a/DI/ValidatorExtension.php
+++ b/DI/ValidatorExtension.php
@@ -29,9 +29,11 @@ class ValidatorExtension extends Nette\DI\CompilerExtension
 		if (!$builder->parameters['debugMode']) {
 			return;
 		}
-
+		
+		$presentersToDisableValidationFor = isset($this->config['presentersToDisableValidationFor']) ? $this->config['presentersToDisableValidationFor'] : [];
+		
 		$builder->addDefinition($this->prefix('panel'))
-			->setClass('Kdyby\Extension\Diagnostics\HtmlValidator\ValidatorPanel')
+			->setClass('Kdyby\Extension\Diagnostics\HtmlValidator\ValidatorPanel', array($presentersToDisableValidationFor) )
 			->addSetup('Tracy\Debugger::getBar()->addPanel(?)', array('@self'));
 
 		$builder->getDefinition('application')

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ extensions:
 ![example](https://raw.githubusercontent.com/Kdyby/HtmlValidatorPanel/master/docs/example.png)
 
 
+Advanced usage
+------------
+You can specify presenters whose outputs you don´t want to parse by HtmlValidator. It can be done in config file somehow like this:
+
+```yml
+htmlPanel:
+	presentersToDisableValidationFor: [
+		App\CustomModule\PagePresenter
+		NetteModule\MicroPresenter
+	]
+```
 
 -----
 

--- a/ValidatorPanel.php
+++ b/ValidatorPanel.php
@@ -771,6 +771,11 @@ class ValidatorPanel implements Tracy\IBarPanel
 	private $errors = array();
 
 	/**
+	 * @var string[]
+	 */
+	private $presentersToDisableValidationFor = array();
+
+	/**
 	 * @var array
 	 */
 	public static $ignoreErrors = array(
@@ -786,7 +791,12 @@ class ValidatorPanel implements Tracy\IBarPanel
 		LIBXML_ERR_FATAL => 'Fatal error',
 	);
 
-
+	/**
+	 * @param string[] $presentersToDisableValidationFor
+	 */
+	public function __construct(array $presentersToDisableValidationFor) {
+		$this->presentersToDisableValidationFor = $presentersToDisableValidationFor;
+	}
 
 	/**
 	 * Renders HTML code for custom tab.
@@ -858,9 +868,14 @@ class ValidatorPanel implements Tracy\IBarPanel
 	/**
 	 * Validate.
 	 */
-	public function validate()
+	public function validate(\Nette\Application\Application $application)
 	{
 		if (!ob_get_level()) {
+			return;
+		}
+		
+		if(in_array(get_class($application->getPresenter()), $this->presentersToDisableValidationFor, true)){
+			ob_end_flush();
 			return;
 		}
 


### PR DESCRIPTION
Following previous [pull request](https://github.com/Kdyby/HtmlValidatorPanel/pull/9) I changed my solution and now you can specify presenters where you dont want to run validation in config file.

For example it can be done like this
```javascript
htmlValidator: 
	disableValidationInPresenters: [
		Company\Fe\CustomPresenter
	]
```
Its allow you to specify presenters its outputs you don't want to validate with HTML validator.
